### PR TITLE
Upgrade token to update symbol to TRUU

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 | Truth Bridge | Sepolia | Development | [0x5816CEDff9DE7c5FB13dcFb1cE9038014b929b7E](https://sepolia.etherscan.io/address/0x5816CEDff9DE7c5FB13dcFb1cE9038014b929b7E#readProxyContract) |
 
 
-## 1. Truth Token (`TRU`)
+## 1. Truth Token (`TRUU`)
 - Standard [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token with a total supply of 100,000,000,000 tokens of 10 decimals.
 - Extended to include [ERC-2612](https://eips.ethereum.org/EIPS/eip-2612) permit-based approvals.
 - Upgradeable.
@@ -62,8 +62,14 @@ Note: when deploying on mainnet the contract `--owner` address must be specified
 #### Upgrade Truth Token
 `npx hardhat upgrade token <token_address> --network <network>`
 
+#### Deploy Truth Token Implementation
+`npx hardhat implementation token --network <network>`
+
 #### Deploy Truth Bridge
 `npx hardhat deploy bridge --token <token_address> [--owner owner_address] --network <network>`
 
 #### Upgrade Truth Bridge
 `npx hardhat upgrade bridge <bridge_address> --network <network>`
+
+#### Deploy Truth Bridge Implementation
+`npx hardhat implementation bridge --network <network>`

--- a/contracts/TruthToken.sol
+++ b/contracts/TruthToken.sol
@@ -8,11 +8,11 @@ import '@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 
 contract TruthToken is Initializable, ERC20Upgradeable, ERC20PermitUpgradeable, Ownable2StepUpgradeable, UUPSUpgradeable {
-  function initialize(string calldata name, string calldata symbol, uint256 supply, address owner_) public initializer {
+  function initialize(string calldata name, string calldata symbol_, uint256 supply, address owner_) public initializer {
     __Ownable_init(owner_);
     __Ownable2Step_init();
     __UUPSUpgradeable_init();
-    __ERC20_init(name, symbol);
+    __ERC20_init(name, symbol_);
     __ERC20Permit_init(name);
     _mint(owner_, supply * 10 ** decimals());
   }
@@ -23,6 +23,10 @@ contract TruthToken is Initializable, ERC20Upgradeable, ERC20PermitUpgradeable, 
 
   function renounceOwnership() public view override onlyOwner {
     revert('Disabled');
+  }
+
+  function symbol() public pure override returns (string memory) {
+    return 'TRUU';
   }
 
   function _authorizeUpgrade(address) internal override onlyOwner {}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,8 +6,29 @@ require('hardhat-contract-sizer');
 require('dotenv').config();
 
 const TOKEN_NAME = 'Truth';
-const TOKEN_SYMBOL = 'TRU';
+const TOKEN_SYMBOL = 'TRUU';
 const TOKEN_SUPPLY = 100000000000n;
+
+task('implementation')
+  .addPositionalParam('contractType')
+  .setAction(async (args, hre) => {
+    await hre.run('compile');
+    const {
+      ethers,
+      network: { name: network }
+    } = hre;
+    const [signer] = await ethers.getSigners();
+    const signerBalance = await ethers.provider.getBalance(signer.address);
+    const contractName = getContractName(args.contractType);
+    console.log(`\nDeploying ${contractName} implementation on ${network} using account ${signer.address}...`);
+    const contractFactory = await ethers.getContractFactory(contractName);
+    const implementation = await contractFactory.deploy();
+    const impAddress = await implementation.getAddress();
+    const cost = ethers.formatEther(signerBalance - (await ethers.provider.getBalance(signer.address)));
+    console.log(`\nDeployed ${contractName} implementation at ${impAddress} for ${cost} ETH\n`);
+    await delay(20);
+    await verify(impAddress);
+  });
 
 task('deploy')
   .addPositionalParam('contractType')

--- a/test/helper.js
+++ b/test/helper.js
@@ -86,7 +86,7 @@ async function deployTruthBridge(truth, owner) {
 async function deployTruthToken(supply, owner) {
   const contract = await ethers.getContractFactory('TruthToken');
   const name = 'Truth';
-  const symbol = 'TRU';
+  const symbol = 'TRUU';
   const token = await upgrades.deployProxy(contract, [name, symbol, supply, owner.address], { kind: 'uups' });
   token.address = await token.getAddress();
   return token;

--- a/test/owner.js
+++ b/test/owner.js
@@ -235,7 +235,7 @@ describe('Owner Functions', async () => {
     });
 
     it('Cannot reinitialize the truth token', async () => {
-      await expect(truth.initialize('Truth2', 'TRU2', 1234567n, owner.address)).to.be.reverted;
+      await expect(truth.initialize('Truth2', 'TRUU2', 1234567n, owner.address)).to.be.reverted;
     });
   });
 

--- a/test/user.js
+++ b/test/user.js
@@ -29,7 +29,7 @@ describe('User Functions', async () => {
   context('Truth token', async () => {
     it('confirm setup', async () => {
       expect(await truth.name()).to.equal('Truth');
-      expect(await truth.symbol()).to.equal('TRU');
+      expect(await truth.symbol()).to.equal('TRUU');
       expect(await truth.decimals()).to.equal(10n);
       expect(await truth.totalSupply()).to.equal(1000000000000000000000n);
       expect(await truth.owner()).to.equal(owner.address);


### PR DESCRIPTION
- Overrides `symbol` in the token contract

- Adds a task to the HH config to deploy standalone implementation contracts

- Updates the docs and tests to the new token symbol