### PR TITLE
Revert T2 lift recipient type to bytes and update dev authors

### DIFF
--- a/authors.json
+++ b/authors.json
@@ -1,29 +1,29 @@
 {
   "dev": [
     {
-      "ethAddress": "0xB43b199F956016C6E8437726c42F95B9B44f6c98",
-      "ethUncompressedPublicKey": "0x04376fdd0add4a5ab1c3536422dd8647b729ad5d35ebeae5358fd54ac2ac7ce7d25d4afcdeb6596aaa3f15b9e9e615ded91a8ec8f722d8efe53155908f7e3f60f4",
-      "t2PublicKey": "0x78155939f63f04d5d9b69cc1cfb3e98c9e7e940cec690a26cbdea7be8b9f7533"
+      "ethAddress": "0x4EFfeDe129e2f74A7Cf8b559Bc7c5713097A7c80",
+      "ethUncompressedPublicKey": "0x04485ee3a192eb693ec705eb437f418a46db3dc3616699b80e6bd77a2389366c02999be2111273982218d67ac0513e60f0f5f28ba5ace67891f6f53bb609c51796",
+      "t2PublicKey": "0xe07e2bf370c83cc5e587bb043b89e405a08eccf951fbda61a8f59992e79dcf79"
     },
     {
-      "ethAddress": "0x6547496874442142896a015E908095616D3946a5",
-      "ethUncompressedPublicKey": "0x04f094c62de2f01a2f26bd1db153bcec9e57a3e94a97cd3fa3702fb4730d9084e4412ffb3f30c36a6828546bfd2ebb72668a1b6660efed614e5190bab048ea05b4",
-      "t2PublicKey": "0x78bbb5eec6e6d79d679d44f0f6ab820d0c0b955def3b05b8f1dbb23f9048592f"
+      "ethAddress": "0x906b3D48f9595888d4ea7fd0ea5769438D1628Ac",
+      "ethUncompressedPublicKey": "0x043aed797b6ee54187db786592a065c48976221a662beddad8ee4f2cfcf04b5604d3220377abd3f4ed0ff48fc2aa0a25756536f280bea526e04a3ec6783b8bf837",
+      "t2PublicKey": "0x724b0c3f8edec4763f1de1aaa763d8b6bbfe898eff0cf84cb0fe21506ba6bc33"
     },
     {
-      "ethAddress": "0x51Ec29ac19994a76EC83859E92A712119ca048DF",
-      "ethUncompressedPublicKey": "0x046e83d53555e68cdb38f8f92be68c0610e08ebe7a6ef9c6ed5ac9dcdf575308a2a5bd87cee23d75770ab065d4674a61235ed8f6d8f0b606fa754c7dbada99cf17",
-      "t2PublicKey": "0xe293b717b63cf1ebce61a0b4dc8a0fcc7670e7ea9638e45dcda46fe23194c377"
+      "ethAddress": "0x360E608b4D6a63646c09A272c02001E21CAb8869",
+      "ethUncompressedPublicKey": "0x0497396dd5aa6ab7bede976e440a4f96324a48e612943f95f436242318f35a127aa0c468882d62fe29539f49b9d6f13918dcb7071d3e3b1748b48b95465f8f3f42",
+      "t2PublicKey": "0xf4cc92fa71b6cc32d93a10d8e828cc6803bb6ea603c1c70b2b5413f7d6ac853e"
     },
     {
-      "ethAddress": "0x73cC017Ed5e34bF3E77fD18CCd4760b25B7e4468",
-      "ethUncompressedPublicKey": "0x04ef2cfe2d40140b9de6b1af5b4d172e3538548bb8f3b55042294915dcbafe45fddfcada08bd227078b954714c227d4550ba5032cdd163764d948dcf9c7cebf7f3",
-      "t2PublicKey": "0x281d02bdcd58e133a269848d1dc1d730df6173f2e13a71a7007e00f0c7a6223e"
+      "ethAddress": "0x82baEdC5e93c59F2ac97c0f65bb4499CBd1ba03A",
+      "ethUncompressedPublicKey": "0x04ea4210cc61cd598f760dd0f7de1c8458ba16cd2c0fc4bef232e484ca820fd51156ed31480107d1db28682b873e05792e3ae7b666552586a50995f5112fc1d29f",
+      "t2PublicKey": "0x6e8e7a18fbcfa0afdb43ebc32e447c162e08129f42b918995660a0e94ddd102b"
     },
     {
-      "ethAddress": "0x58f272b4F59d8E28954cA7FBE19E3C5D8F52F4a7",
-      "ethUncompressedPublicKey": "0x041473964134e3f5603ccb563dbafafff81e1047c7d7c8cd1cd62cd033f43697efc6d062cdf236d4af1f7d0b4abcac590938add7d7b114cacb435db364bc93f4fc",
-      "t2PublicKey": "0x8af997028297e0b69be1bf436ac3a6dec6438badfdb281e637caff3c54d23642"
+      "ethAddress": "0xB1DD07E7DF6b2f11A9305a98cbcdb7Dc403f9655",
+      "ethUncompressedPublicKey": "0x0431ebb34b20b5f9d2761feef8f55ab50a5041634a7e190945ddf9c9c847dd851c45d9a6182da1a627579fce5a99b7d0c97a6929e7ac589826d97aa1adf4059f0e",
+      "t2PublicKey": "0x6884166b647a650bfb9670d3d0f316fc6243177ad9465a0165b049577246ef69"
     }
   ],
   "testnet": [

--- a/contracts/interfaces/ITruthBridge.sol
+++ b/contracts/interfaces/ITruthBridge.sol
@@ -12,8 +12,8 @@ interface ITruthBridge {
   function addAuthor(bytes calldata t1PubKey, bytes32 t2PubKey, uint256 expiry, uint32 t2TxId, bytes calldata confirmations) external;
   function removeAuthor(bytes32 t2PubKey, bytes calldata t1PubKey, uint256 expiry, uint32 t2TxId, bytes calldata confirmations) external;
   function publishRoot(bytes32 rootHash, uint256 expiry, uint32 t2TxId, bytes calldata confirmations) external;
-  function lift(address token, bytes32 t2PubKey, uint256 amount) external;
-  function lift(address token, bytes32 t2PubKey, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+  function lift(address token, bytes calldata t2PubKey, uint256 amount) external;
+  function lift(address token, bytes calldata t2PubKey, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
   function liftToPredictionMarket(address token, uint256 amount) external;
   function liftToPredictionMarket(address token, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
   function claimLower(bytes calldata proof) external;

--- a/contracts/test/ReentrantToken.sol
+++ b/contracts/test/ReentrantToken.sol
@@ -19,7 +19,7 @@ contract ReentrantToken is ERC20 {
 
   bytes private _proof;
   address private _token;
-  bytes32 private _t2PubKey;
+  bytes private _t2PubKey;
   uint256 private _amount;
   uint256 private _deadline;
   uint8 private _v;

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,7 +3,7 @@ const { MerkleTree } = require('merkletreejs');
 const { expect } = require('chai');
 const coder = ethers.AbiCoder.defaultAbiCoder();
 
-const EMPTY_32_BYTES = '0x0000000000000000000000000000000000000000000000000000000000000000';
+const EMPTY_BYTES = '0x';
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const LOWER_ID = '0x5702';
 const EXPIRY_WINDOW = 60;
@@ -273,7 +273,7 @@ module.exports = {
   deployTruthBridge,
   deployTruthToken,
   expect,
-  EMPTY_32_BYTES,
+  EMPTY_BYTES,
   EXPIRY_WINDOW,
   getAccounts: () => accounts,
   getAuthors: () => authors,

--- a/test/user.js
+++ b/test/user.js
@@ -3,7 +3,7 @@ const {
   createTreeAndPublishRoot,
   deployTruthBridge,
   deployTruthToken,
-  EMPTY_32_BYTES,
+  EMPTY_BYTES,
   expect,
   getAccounts,
   getNumRequiredConfirmations,
@@ -87,12 +87,12 @@ describe('User Functions', async () => {
       });
 
       it('attempting to lift tokens without supplying a T2 public key', async () => {
-        await expect(bridge.lift(truth.address, EMPTY_32_BYTES, amount)).to.be.revertedWithCustomError(bridge, 'InvalidT2Key');
+        await expect(bridge.lift(truth.address, EMPTY_BYTES, amount)).to.be.revertedWithCustomError(bridge, 'InvalidT2Key');
       });
 
       it('attempting to lift tokens with a permit but without supplying a T2 public key', async () => {
         const permit = await getPermit(truth, owner, bridge, amount);
-        await expect(bridge.lift(truth.address, EMPTY_32_BYTES, amount, permit.deadline, permit.v, permit.r, permit.s)).to.be.revertedWithCustomError(
+        await expect(bridge.lift(truth.address, EMPTY_BYTES, amount, permit.deadline, permit.v, permit.r, permit.s)).to.be.revertedWithCustomError(
           bridge,
           'InvalidT2Key'
         );


### PR DESCRIPTION
- Passing bytes type costs 600 more gas than bytes32 but avoids having to update the dapps
- Updates the author set for the dev environment