### PR TITLE
Enable lift variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,18 @@
     - **Lowering** - Unlocking and transferring tokens to the Ethereum recipient specified in the proof of the tokens' destruction on the TN.
 - Upgradeable.
 
+## Lift Methods
+
+| Method                        | Approval Tx Required? | Callable By | T2 Account Specified As         |
+|-------------------------------|-----------------------|-------------|---------------------------------|
+| **lift**                      | Yes                   | Lifter      | `bytes`                         |
+| **permitLift**                | No                    | Lifter      | `bytes32`                       |
+| **proxyLift**                 | No                    | Anyone      | `bytes32`                       |
+| **predictionMarketLift**      | Yes                   | Lifter      | Derived from lifter ETH address |
+| **predictionMarketPermitLift**| No                    | Lifter      | Derived from lifter ETH address |
+| **predictionMarketProxyLift** | No                    | Anyone      | Derived from lifter ETH address |
+
+
 # Development
 
 ## Setup

--- a/contracts/interfaces/ITruthBridge.sol
+++ b/contracts/interfaces/ITruthBridge.sol
@@ -13,9 +13,11 @@ interface ITruthBridge {
   function removeAuthor(bytes32 t2PubKey, bytes calldata t1PubKey, uint256 expiry, uint32 t2TxId, bytes calldata confirmations) external;
   function publishRoot(bytes32 rootHash, uint256 expiry, uint32 t2TxId, bytes calldata confirmations) external;
   function lift(address token, bytes calldata t2PubKey, uint256 amount) external;
-  function lift(address token, bytes calldata t2PubKey, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
-  function liftToPredictionMarket(address token, uint256 amount) external;
-  function liftToPredictionMarket(address token, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+  function permitLift(address token, bytes32 t2PubKey, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+  function proxyLift(address token, address lifter, bytes32 t2PubKey, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+  function predictionMarketLift(address token, uint256 amount) external;
+  function predictionMarketPermitLift(address token, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+  function predictionMarketProxyLift(address token, address lifter, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
   function claimLower(bytes calldata proof) external;
   function checkLower(
     bytes calldata proof

--- a/contracts/test/ReentrantToken.sol
+++ b/contracts/test/ReentrantToken.sol
@@ -9,9 +9,11 @@ contract ReentrantToken is ERC20 {
   enum ReentryPoint {
     ClaimLower,
     Lift,
-    LiftPermit,
-    LiftPM,
-    LiftPMPermit
+    PermitLift,
+    ProxyLift,
+    PredicitonMarketLift,
+    PredicitonMarketPermitLift,
+    PredicitonMarketProxyLift
   }
 
   ReentryPoint private _reentryPoint;
@@ -19,7 +21,8 @@ contract ReentrantToken is ERC20 {
 
   bytes private _proof;
   address private _token;
-  bytes private _t2PubKey;
+  bytes private _t2PubKeyBytes;
+  bytes32 private _t2PubKey;
   uint256 private _amount;
   uint256 private _deadline;
   uint8 private _v;
@@ -44,9 +47,11 @@ contract ReentrantToken is ERC20 {
 
   function _attemptReentry() private {
     if (_reentryPoint == ReentryPoint.ClaimLower) _bridge.claimLower(_proof);
-    else if (_reentryPoint == ReentryPoint.Lift) _bridge.lift(_token, _t2PubKey, _amount);
-    else if (_reentryPoint == ReentryPoint.LiftPermit) _bridge.lift(_token, _t2PubKey, _amount, _deadline, _v, _r, _s);
-    else if (_reentryPoint == ReentryPoint.LiftPM) _bridge.liftToPredictionMarket(_token, _amount);
-    else if (_reentryPoint == ReentryPoint.LiftPMPermit) _bridge.liftToPredictionMarket(_token, _amount, _deadline, _v, _r, _s);
+    else if (_reentryPoint == ReentryPoint.Lift) _bridge.lift(_token, _t2PubKeyBytes, _amount);
+    else if (_reentryPoint == ReentryPoint.PermitLift) _bridge.permitLift(_token, _t2PubKey, _amount, _deadline, _v, _r, _s);
+    else if (_reentryPoint == ReentryPoint.ProxyLift) _bridge.proxyLift(_token, msg.sender, _t2PubKey, _amount, _deadline, _v, _r, _s);
+    else if (_reentryPoint == ReentryPoint.PredicitonMarketLift) _bridge.predictionMarketLift(_token, _amount);
+    else if (_reentryPoint == ReentryPoint.PredicitonMarketPermitLift) _bridge.predictionMarketPermitLift(_token, _amount, _deadline, _v, _r, _s);
+    else if (_reentryPoint == ReentryPoint.PredicitonMarketProxyLift) _bridge.predictionMarketProxyLift(_token, msg.sender, _amount, _deadline, _v, _r, _s);
   }
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -4,6 +4,7 @@ const { expect } = require('chai');
 const coder = ethers.AbiCoder.defaultAbiCoder();
 
 const EMPTY_BYTES = '0x';
+const EMPTY_BYTES_32 = '0x0000000000000000000000000000000000000000000000000000000000000000';
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const LOWER_ID = '0x5702';
 const EXPIRY_WINDOW = 60;
@@ -274,6 +275,7 @@ module.exports = {
   deployTruthToken,
   expect,
   EMPTY_BYTES,
+  EMPTY_BYTES_32,
   EXPIRY_WINDOW,
   getAccounts: () => accounts,
   getAuthors: () => authors,


### PR DESCRIPTION
Updates lifting so each variant has its unique signature and functions correctly:

## Lift Methods

| Method                        | Approval Tx Required? | Callable By | T2 Account Specified As         |
|-------------------------------|-----------------------|-------------|---------------------------------|
| **lift**                      | Yes                   | Lifter      | `bytes`                         |
| **permitLift**                | No                    | Lifter      | `bytes32`                       |
| **proxyLift**                 | No                    | Anyone      | `bytes32`                       |
| **predictionMarketLift**      | Yes                   | Lifter      | Derived from lifter ETH address |
| **predictionMarketPermitLift**| No                    | Lifter      | Derived from lifter ETH address |
| **predictionMarketProxyLift** | No                    | Anyone      | Derived from lifter ETH address |
 
![image](https://github.com/user-attachments/assets/0842f4f4-3d6f-44c7-83a9-c23b05f7a632)
