### PR TITLE
Add relayer on-ramping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 - Handles:
   - Adding, activating and removing authors (TN block creators) by author consensus.
   - Periodically checkpointing TN transactions (summarised as Merkle roots) by author consensus.
+  - "Gasless" completion of user on-ramping by registered relayer accounts. 
+  - Management of relayers.
   - The movement of ERC20 tokens between Ethereum and TN by:
     - **Lifting** - Locking received tokens in the contract and authorising their re-creation in the specified TN recipient account.
     - **Lowering** - Unlocking and transferring tokens to the Ethereum recipient specified in the proof of the tokens' destruction on the TN.

--- a/contracts/TruthBridge.sol
+++ b/contracts/TruthBridge.sol
@@ -7,11 +7,15 @@ pragma solidity 0.8.28;
  * Allows Authors to be added and removed from participation in consensus.
  * "lifts" tokens from Ethereum addresses to Truth Network accounts.
  * "lowers" tokens from Truth Network accounts to Ethereum addresses.
+ * Enables gas-free on-ramping of USDC funds via relayers.
  * Accepts optional ERC-2612 permits for lifting.
  * Proxy upgradeable implementation utilising EIP-1822.
  */
 
 import './interfaces/ITruthBridge.sol';
+import './interfaces/IChainlinkV3Aggregator.sol';
+import './interfaces/IUniswapV3Pool.sol';
+import './interfaces/IWETH9.sol';
 import '@openzeppelin/contracts/interfaces/IERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol';
@@ -30,6 +34,7 @@ contract TruthBridge is ITruthBridge, Initializable, Ownable2StepUpgradeable, Pa
   uint256 private constant SIGNATURE_LENGTH = 65;
   uint256 private constant T2_TOKEN_LIMIT = type(uint128).max;
   uint256 private constant MINIMUM_PROOF_LENGTH = LOWER_DATA_LENGTH + SIGNATURE_LENGTH * 2;
+  uint160 private constant UNISWAP_SRPLX96 = 4295128739 + 1; // 1 over the minimum allowed sqrt price limit in Uniswap V3.
   int8 private constant TX_SUCCEEDED = 1;
   int8 private constant TX_PENDING = 0;
   int8 private constant TX_FAILED = -1;
@@ -48,15 +53,21 @@ contract TruthBridge is ITruthBridge, Initializable, Ownable2StepUpgradeable, Pa
   mapping(bytes32 => bool) public isPublishedRootHash;
   mapping(uint256 => bool) public isUsedT2TxId;
   mapping(bytes32 => bool) public hasLowered;
+  mapping(address => int256) public relayerBalance;
 
   uint256 public numActiveAuthors;
   uint256 public nextAuthorId;
+  uint256 public onRampGas;
   address public truth;
 
   error AddressMismatch(); // 0x4cd87fb5
   error AlreadyAdded(); // 0xf411c327
+  error AmountTooLow(); // 0x1fbaba35
   error BadConfirmations(); // 0x409c8aac
   error CannotChangeT2Key(bytes32); // 0x140c6815
+  error ExcessSlippage(); // 0x5668e7fc
+  error FeedFailure(); // 0x6148950d
+  error InvalidCallback(); // 0xf7a632f5
   error InvalidProof(); // 0x09bde339
   error InvalidT1Key(); // 0x4b0218a8
   error InvalidT2Key(); // 0xf4fc87a4
@@ -67,9 +78,12 @@ contract TruthBridge is ITruthBridge, Initializable, Ownable2StepUpgradeable, Pa
   error MissingTruth(); // 0xd1585e94
   error NotAnAuthor(); // 0x157b0512
   error NotEnoughAuthors(); // 0x3a6a875c
+  error NothingToRecover(); // 0xaba3a548
+  error RelayerOnly(); // 0x7378cebb
   error RootHashIsUsed(); // 0x2c8a3b6e
   error T1AddressInUse(address); // 0x78f22dd1
   error T2KeyInUse(bytes32); // 0x02f3935c
+  error TransferFailed(); // 0x90b8ec18
   error TxIdIsUsed(); // 0x7edd16f0
   error WindowExpired(); // 0x7bbfb6fe
 
@@ -99,6 +113,7 @@ contract TruthBridge is ITruthBridge, Initializable, Ownable2StepUpgradeable, Pa
     if (_truth == address(0)) revert MissingTruth();
     truth = _truth;
     nextAuthorId = 1;
+    onRampGas = 110000;
     _initialiseAuthors(t1Addresses, t1PubKeysLHS, t1PubKeysRHS, t2PubKeys);
   }
 
@@ -247,6 +262,89 @@ contract TruthBridge is ITruthBridge, Initializable, Ownable2StepUpgradeable, Pa
     IERC20Permit(token).permit(lifter, address(this), amount, deadline, v, r, s);
     emit LogLiftedToPredictionMarket(token, deriveT2PublicKey(lifter), _lift(lifter, token, amount));
   }
+
+  /**
+   * @dev Registers a relayer for proxying user on-ramp completions
+   */
+  function registerRelayer(address relayer) external onlyOwner {
+    if (relayerBalance[relayer] == 0) {
+      relayerBalance[relayer] = 1; // minimizes storage reads by using trace balance to denote a registered relayer
+      emit LogRelayerRegistered(relayer);
+    } else revert(); // relayer already registered
+  }
+
+  /**
+   * @dev Deregisters an existing relayer
+   */
+  function deregisterRelayer(address relayer) external onlyOwner {
+    int256 balance = relayerBalance[relayer];
+    if (balance == 0) revert(); // no such relayer
+    relayerBalance[relayer] = 0;
+    if (balance > 1) IERC20(usdc).transfer(relayer, uint256(balance - 1)); // transfer any unclaimed USDC
+    emit LogRelayerDeregistered(relayer);
+  }
+
+  /**
+   * @dev Adjusts the gas for the on-ramp
+   */
+  function setOnRampGas(uint256 _onRampGas) external onlyOwner {
+    onRampGas = _onRampGas;
+  }
+
+  /**
+   * @dev Enables a relayer to lift USDC to the prediciton market on behalf of a user and extract the tx cost from the USDC
+   */
+  function completeOnRamp(uint256 amount, address user, uint8 v, bytes32 r, bytes32 s) external {
+    int256 balance = relayerBalance[msg.sender];
+    if (balance < 1) revert RelayerOnly();
+    unchecked {
+      uint256 usdcTxCost = (tx.gasprice * onRampGas) / usdcEth();
+      if (amount > usdcTxCost) {
+        IERC20Permit(usdc).permit(user, address(this), amount, type(uint256).max, v, r, s);
+        IERC20(usdc).transferFrom(user, address(this), amount);
+        relayerBalance[msg.sender] = balance + int256(usdcTxCost);
+        emit LogLiftedToPredictionMarket(usdc, deriveT2PublicKey(user), amount - usdcTxCost);
+      } else revert AmountTooLow();
+    }
+  }
+
+  /**
+   * @dev Allows relayers to recover their ETH costs
+   */
+  function recoverCosts() external {
+    int256 balance = relayerBalance[msg.sender];
+    if (balance < 2) revert NothingToRecover();
+    relayerBalance[msg.sender] = 1; // retain trace registration balance
+    IUniswapV3Pool(pool).swap(address(this), true, balance, UNISWAP_SRPLX96, ''); // triggers callback to take the funds
+    uint256 ethAmount = IERC20(weth).balanceOf(address(this));
+    unchecked {
+      if (ethAmount < (uint256(balance) * usdcEth() * 985) / 1000) revert ExcessSlippage();
+    }
+    IWETH9(weth).withdraw(ethAmount);
+    (bool success, ) = msg.sender.call{ value: ethAmount }('');
+    if (!success) revert TransferFailed();
+  }
+
+  /**
+   * @dev Returns the current Wei value of 1 USDC
+   */
+  function usdcEth() public view returns (uint256 price) {
+    unchecked {
+      price = uint256(IChainlinkV3Aggregator(feed).latestAnswer()) / 1e6;
+    }
+    if (price == 0) revert FeedFailure();
+  }
+
+  /**
+   * @dev Only callable by the Uniswap pool to complete the swap in recoverCosts
+   */
+  function uniswapV3SwapCallback(int256 amount0Delta, int256 /* amount1Delta */, bytes calldata /* data */) external {
+    if (msg.sender != pool) revert InvalidCallback();
+    IERC20(usdc).transfer(msg.sender, uint256(amount0Delta));
+  }
+
+  // Allows the contract to receive ETH (from WETH withdrawal).
+  receive() external payable {}
 
   /** @dev Checks a lower proof. Returns the details, proof validity, and claim status.
    * For unclaimed lowers, if the required confirmations exceeds those provided the proof will need to be regenerated.

--- a/contracts/interfaces/ITruthBridge.sol
+++ b/contracts/interfaces/ITruthBridge.sol
@@ -8,6 +8,8 @@ interface ITruthBridge {
   event LogLiftedToPredictionMarket(address indexed token, bytes32 indexed t2PubKey, uint256 amount);
   event LogLowerClaimed(uint32 indexed lowerId);
   event LogRootPublished(bytes32 indexed rootHash, uint32 indexed t2TxId);
+  event LogRelayerRegistered(address indexed relayer);
+  event LogRelayerDeregistered(address indexed relayer);
 
   function addAuthor(bytes calldata t1PubKey, bytes32 t2PubKey, uint256 expiry, uint32 t2TxId, bytes calldata confirmations) external;
   function removeAuthor(bytes32 t2PubKey, bytes calldata t1PubKey, uint256 expiry, uint32 t2TxId, bytes calldata confirmations) external;
@@ -18,6 +20,12 @@ interface ITruthBridge {
   function predictionMarketLift(address token, uint256 amount) external;
   function predictionMarketPermitLift(address token, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
   function predictionMarketProxyLift(address token, address lifter, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+  function registerRelayer(address relayer) external;
+  function deregisterRelayer(address relayer) external;
+  function setOnRampGas(uint256 onRampGas) external;
+  function completeOnRamp(uint256 amount, address user, uint8 v, bytes32 r, bytes32 s) external;
+  function recoverCosts() external;
+  function usdcEth() external view returns (uint256 price);
   function claimLower(bytes calldata proof) external;
   function checkLower(
     bytes calldata proof

--- a/test/helper.js
+++ b/test/helper.js
@@ -211,8 +211,12 @@ function printErrorCodes() {
   [
     'AddressMismatch()',
     'AlreadyAdded()',
+    'AmountTooLow()',
     'BadConfirmations()',
     'CannotChangeT2Key(bytes32)',
+    'ExcessSlippage()',
+    'FeedFailure()',
+    'InvalidCallback()',
     'InvalidProof()',
     'InvalidT1Key()',
     'InvalidT2Key()',
@@ -223,9 +227,12 @@ function printErrorCodes() {
     'MissingTruth()',
     'NotAnAuthor()',
     'NotEnoughAuthors()',
+    'NothingToRecover()',
+    'RelayerOnly()',
     'RootHashIsUsed()',
     'T1AddressInUse(address)',
     'T2KeyInUse(bytes32)',
+    'TransferFailed()',
     'TxIdIsUsed()',
     'WindowExpired()'
   ].forEach(error => console.log(`error ${error}; // ${ethers.keccak256(ethers.toUtf8Bytes(error)).slice(0, 10)}`));

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -1,0 +1,187 @@
+const { deployTruthBridge, deployTruthToken, expect, getAccounts, getPermit, getUSDC, init, ONE_HUNDRED_BILLION, ONE_USDC, sendUSDC } = require('./helper.js');
+
+let bridge, truth, usdc, owner, otherAccount, relayer1, relayer2, user, t2PubKey;
+
+describe('Relayer Functions', async () => {
+  before(async () => {
+    const numAuthors = 6;
+    await init(numAuthors);
+    [owner, otherAccount, relayer1, relayer2, user] = getAccounts();
+    truth = await deployTruthToken(ONE_HUNDRED_BILLION, owner);
+    bridge = await deployTruthBridge(truth, owner);
+    usdc = await getUSDC();
+    userT2PubKey = await bridge.deriveT2PublicKey(user.address);
+  });
+
+  context('Registering relayers', async () => {
+    context('succeeds', async () => {
+      it('when the caller is the owner', async () => {
+        expect(await bridge.relayerBalance(relayer1.address)).to.equal(0);
+        await expect(bridge.registerRelayer(relayer1.address)).to.emit(bridge, 'LogRelayerRegistered').withArgs(relayer1.address);
+        expect(await bridge.relayerBalance(relayer1.address)).to.equal(1);
+      });
+    });
+
+    context('fails', async () => {
+      it('when the relayer is already registered', async () => {
+        await expect(bridge.registerRelayer(relayer1.address)).to.be.reverted;
+      });
+
+      it('when the caller is not the owner', async () => {
+        await expect(bridge.connect(otherAccount).registerRelayer(relayer2.address)).to.be.revertedWithCustomError(bridge, 'OwnableUnauthorizedAccount');
+      });
+    });
+  });
+
+  context('Deregistering relayers', async () => {
+    context('succeeds', async () => {
+      it('when the caller is the owner', async () => {
+        expect(await bridge.relayerBalance(relayer1.address)).to.equal(1);
+        await expect(bridge.deregisterRelayer(relayer1.address)).to.emit(bridge, 'LogRelayerDeregistered').withArgs(relayer1.address);
+        expect(await bridge.relayerBalance(relayer1.address)).to.equal(0);
+      });
+
+      it('when the relayer is owed USDC it is returned to them before deregistration', async () => {
+        await bridge.registerRelayer(relayer2.address);
+        const amount = 10n * ONE_USDC;
+        await sendUSDC(user, amount);
+        const permit = await getPermit(usdc, user, bridge, amount, ethers.MaxUint256);
+        await bridge.connect(relayer2).completeOnRamp(amount, user.address, permit.v, permit.r, permit.s);
+
+        expect(await usdc.balanceOf(relayer2.address)).to.equal(0);
+        expect(await bridge.relayerBalance(relayer2.address)).to.be.greaterThan(1);
+        const relayerBalance = await bridge.relayerBalance(relayer2.address);
+        await bridge.deregisterRelayer(relayer2.address);
+        expect(await usdc.balanceOf(relayer2.address)).to.equal(relayerBalance - 1n);
+      });
+    });
+
+    context('fails', async () => {
+      it('when the relayer is already deregistered', async () => {
+        await expect(bridge.deregisterRelayer(relayer1.address)).to.be.reverted;
+      });
+
+      it('when the caller is not the owner', async () => {
+        await expect(bridge.connect(otherAccount).deregisterRelayer(relayer1.address)).to.be.revertedWithCustomError(bridge, 'OwnableUnauthorizedAccount');
+      });
+    });
+  });
+
+  context('Setting onRampGas', async () => {
+    context('succeeds', async () => {
+      it('when the caller is the owner', async () => {
+        let onRampGas = await bridge.onRampGas();
+        onRampGas = onRampGas + 1n;
+        await bridge.setOnRampGas(onRampGas);
+        expect(await bridge.onRampGas()).to.equal(onRampGas);
+      });
+    });
+
+    context('fails', async () => {
+      it('when the caller is not the owner', async () => {
+        await expect(bridge.connect(otherAccount).setOnRampGas(1)).to.be.revertedWithCustomError(bridge, 'OwnableUnauthorizedAccount');
+      });
+    });
+  });
+
+  context('Completing on-ramping', async () => {
+    async function getTxCost() {
+      const { gasPrice } = await ethers.provider.getFeeData();
+      return (gasPrice * (await bridge.onRampGas())) / (await bridge.usdcEth());
+    }
+
+    context('succeeds', async () => {
+      before(async () => {
+        await bridge.registerRelayer(relayer1.address);
+      });
+
+      it('when called by a relayer with a valid user permit', async () => {
+        const amount = 10n * ONE_USDC;
+        await sendUSDC(user, amount);
+        const initialBalance = await usdc.balanceOf(bridge.address);
+        const permit = await getPermit(usdc, user, bridge, amount, ethers.MaxUint256);
+        const expectedFee = await getTxCost();
+        expect(await bridge.connect(relayer1).completeOnRamp(amount, user.address, permit.v, permit.r, permit.s))
+          .to.emit(bridge, 'LogLiftedToPredictionMarket')
+          .withArgs(usdc.address, userT2PubKey, amount - expectedFee);
+        expect(await usdc.balanceOf(bridge.address)).to.equal(initialBalance + amount);
+      });
+    });
+
+    context('fails', async () => {
+      it('if the caller is not a relayer', async () => {
+        const amount = 1n * ONE_USDC;
+        await sendUSDC(user, amount);
+        const permit = await getPermit(usdc, user, bridge, amount, ethers.MaxUint256);
+        await expect(bridge.connect(otherAccount).completeOnRamp(amount, user.address, permit.v, permit.r, permit.s)).to.be.revertedWithCustomError(
+          bridge,
+          'RelayerOnly'
+        );
+      });
+
+      it('if the permit is invalid', async () => {
+        const amount = 10n * ONE_USDC;
+        const permit = await getPermit(usdc, user, bridge, amount, ethers.MaxUint256);
+        await expect(bridge.connect(relayer1).completeOnRamp(amount, otherAccount.address, permit.v, permit.r, permit.s)).to.be.reverted;
+      });
+
+      it('if the amount will not cover the tx cost', async () => {
+        const txCost = await getTxCost();
+        await sendUSDC(user, txCost * 2n);
+        let amount = txCost - 1n;
+        let permit = await getPermit(usdc, user, bridge, amount, ethers.MaxUint256);
+        await expect(bridge.connect(relayer1).completeOnRamp(amount, user.address, permit.v, permit.r, permit.s)).to.be.revertedWithCustomError(
+          bridge,
+          'AmountTooLow'
+        );
+        amount = txCost + 1n;
+        permit = await getPermit(usdc, user, bridge, amount, ethers.MaxUint256);
+        await bridge.connect(relayer1).completeOnRamp(amount, user.address, permit.v, permit.r, permit.s);
+      });
+    });
+  });
+
+  context('Recovering costs', async () => {
+    context('succeeds', async () => {
+      it('when called by a relayer with an unclaimed balance', async () => {
+        await bridge.connect(relayer1).recoverCosts();
+      });
+    });
+
+    context('fails', async () => {
+      it('if the caller is not a relayer', async () => {
+        await expect(bridge.connect(otherAccount).recoverCosts()).to.be.revertedWithCustomError(bridge, 'NothingToRecover');
+      });
+
+      it('when the Uniswap callback is invoked by any account other than the permitted pool', async () => {
+        await expect(bridge.uniswapV3SwapCallback(1, 1, '0x')).to.be.revertedWithCustomError(bridge, 'InvalidCallback');
+      });
+    });
+  });
+
+  context('Completing the on-ramp', async () => {
+    context('succeeds', async () => {
+      async function doOnRamp() {
+        const amount = 10n * ONE_USDC;
+        await sendUSDC(user, amount);
+        const permit = await getPermit(usdc, user, bridge, amount, ethers.MaxUint256);
+        const { gasPrice } = await ethers.provider.getFeeData();
+        const expectedFee = (gasPrice * (await bridge.onRampGas())) / (await bridge.usdcEth());
+        expect(await bridge.connect(relayer1).completeOnRamp(amount, user.address, permit.v, permit.r, permit.s))
+          .to.emit(bridge, 'LogLiftedToPredictionMarket')
+          .withArgs(usdc.address, t2PubKey, amount - expectedFee);
+      }
+
+      it('when called by a relayer', async () => {
+        const initialBalance = await ethers.provider.getBalance(relayer1.address);
+        for (i = 0; i < 100; i++) {
+          await doOnRamp();
+        }
+
+        await bridge.connect(relayer1).recoverCosts();
+        const gainOrLoss = (await ethers.provider.getBalance(relayer1.address)) - initialBalance;
+        console.log(gainOrLoss);
+      });
+    });
+  });
+});

--- a/test/relayer.js
+++ b/test/relayer.js
@@ -180,7 +180,7 @@ describe('Relayer Functions', async () => {
 
         await bridge.connect(relayer1).recoverCosts();
         const gainOrLoss = (await ethers.provider.getBalance(relayer1.address)) - initialBalance;
-        console.log(gainOrLoss);
+        // console.log(gainOrLoss);
       });
     });
   });


### PR DESCRIPTION
- Relayer accounts call `completeOnRamp` on behalf of users to lift their USDC for them, with a portion being deducted to pay the relayer fairly for the transaction.

- The relayer can periodically call `recoverCosts` which swaps their current USDC balance (held in the contract) to ETH and refunds it to them.

- Both functions rely on the current USDC/ETH price, pulled from the Chainlink feed on mainnet and a custom feed on Sepolia.

- Adds the ability for the contract owner to register/deregister relayer accounts, and to update the on-ramping gas cost if required (ie: future opcode updates, increase/decrease the recovery cost buffer)
