### PR TITLE
Remove proxy lift and disable token initializer

### DIFF
--- a/.openzeppelin/sepolia.json
+++ b/.openzeppelin/sepolia.json
@@ -18,6 +18,7 @@
     },
     {
       "address": "0x5816CEDff9DE7c5FB13dcFb1cE9038014b929b7E",
+      "txHash": "0x8195c91ae7eae9d353ce476e32c8178c19b138bf2ccc8ef06fadccdd2e5785d0",
       "kind": "uups"
     }
   ],
@@ -1163,6 +1164,599 @@
           ]
         }
       }
+    },
+    "3245470658646cc5044d2531c84cee9a99cb0162bfb49804d20fa2ed71b9361d": {
+      "address": "0xbccB8DdDBbDe67Eb258C032d7A7A069780596101",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(EIP712Storage)724_storage": {
+            "label": "struct EIP712Upgradeable.EIP712Storage",
+            "members": [
+              {
+                "label": "_hashedName",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_hashedVersion",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_version",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(ERC20Storage)272_storage": {
+            "label": "struct ERC20Upgradeable.ERC20Storage",
+            "members": [
+              {
+                "label": "_balances",
+                "type": "t_mapping(t_address,t_uint256)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_allowances",
+                "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_totalSupply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "_name",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "_symbol",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_struct(InitializableStorage)128_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(NoncesStorage)543_storage": {
+            "label": "struct NoncesUpgradeable.NoncesStorage",
+            "members": [
+              {
+                "label": "_nonces",
+                "type": "t_mapping(t_address,t_uint256)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Ownable2StepStorage)13_storage": {
+            "label": "struct Ownable2StepUpgradeable.Ownable2StepStorage",
+            "members": [
+              {
+                "label": "_pendingOwner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)68_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.Ownable2Step": [
+            {
+              "contract": "Ownable2StepUpgradeable",
+              "label": "_pendingOwner",
+              "type": "t_address",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\Ownable2StepUpgradeable.sol:29",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Nonces": [
+            {
+              "contract": "NoncesUpgradeable",
+              "label": "_nonces",
+              "type": "t_mapping(t_address,t_uint256)",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\NoncesUpgradeable.sol:17",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.EIP712": [
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedName",
+              "type": "t_bytes32",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\cryptography\\EIP712Upgradeable.sol:39",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_hashedVersion",
+              "type": "t_bytes32",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\cryptography\\EIP712Upgradeable.sol:41",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\cryptography\\EIP712Upgradeable.sol:43",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "EIP712Upgradeable",
+              "label": "_version",
+              "type": "t_string_storage",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\cryptography\\EIP712Upgradeable.sol:44",
+              "offset": 0,
+              "slot": "3"
+            }
+          ],
+          "erc7201:openzeppelin.storage.ERC20": [
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_balances",
+              "type": "t_mapping(t_address,t_uint256)",
+              "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:33",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_allowances",
+              "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+              "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:35",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_totalSupply",
+              "type": "t_uint256",
+              "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:37",
+              "offset": 0,
+              "slot": "2"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:39",
+              "offset": 0,
+              "slot": "3"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_symbol",
+              "type": "t_string_storage",
+              "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC20\\ERC20Upgradeable.sol:40",
+              "offset": 0,
+              "slot": "4"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0xbccB8DdDBbDe67Eb258C032d7A7A069780596101"
+      ]
+    },
+    "c4a332dbf7f5a26e13168aa4644935f66bf2b56a4abce13e0d17d6a57bcfa292": {
+      "address": "0xEE158E19450d4De36222E8C0F894a1193408885A",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "isAuthor",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:48"
+          },
+          {
+            "label": "authorIsActive",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:49"
+          },
+          {
+            "label": "t1AddressToId",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:50"
+          },
+          {
+            "label": "t2PubKeyToId",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:51"
+          },
+          {
+            "label": "idToT1Address",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:52"
+          },
+          {
+            "label": "idToT2PubKey",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_mapping(t_uint256,t_bytes32)",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:53"
+          },
+          {
+            "label": "isPublishedRootHash",
+            "offset": 0,
+            "slot": "6",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:54"
+          },
+          {
+            "label": "isUsedT2TxId",
+            "offset": 0,
+            "slot": "7",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:55"
+          },
+          {
+            "label": "hasLowered",
+            "offset": 0,
+            "slot": "8",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:56"
+          },
+          {
+            "label": "numActiveAuthors",
+            "offset": 0,
+            "slot": "9",
+            "type": "t_uint256",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:57"
+          },
+          {
+            "label": "nextAuthorId",
+            "offset": 0,
+            "slot": "10",
+            "type": "t_uint256",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:58"
+          },
+          {
+            "label": "truth",
+            "offset": 0,
+            "slot": "11",
+            "type": "t_address",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:59"
+          },
+          {
+            "label": "relayerBalance",
+            "offset": 0,
+            "slot": "12",
+            "type": "t_mapping(t_address,t_int256)",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:62"
+          },
+          {
+            "label": "onRampGas",
+            "offset": 0,
+            "slot": "13",
+            "type": "t_uint256",
+            "contract": "TruthBridge",
+            "src": "contracts\\TruthBridge.sol:63"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_struct(InitializableStorage)128_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(Ownable2StepStorage)13_storage": {
+            "label": "struct Ownable2StepUpgradeable.Ownable2StepStorage",
+            "members": [
+              {
+                "label": "_pendingOwner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(OwnableStorage)68_storage": {
+            "label": "struct OwnableUpgradeable.OwnableStorage",
+            "members": [
+              {
+                "label": "_owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)274_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(ReentrancyGuardStorage)338_storage": {
+            "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
+            "members": [
+              {
+                "label": "_status",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_int256": {
+            "label": "int256",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_int256)": {
+            "label": "mapping(address => int256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bool)": {
+            "label": "mapping(uint256 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bytes32)": {
+            "label": "mapping(uint256 => bytes32)",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ReentrancyGuard": [
+            {
+              "contract": "ReentrancyGuardUpgradeable",
+              "label": "_status",
+              "type": "t_uint256",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\ReentrancyGuardUpgradeable.sol:43",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable2Step": [
+            {
+              "contract": "Ownable2StepUpgradeable",
+              "label": "_pendingOwner",
+              "type": "t_address",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\Ownable2StepUpgradeable.sol:29",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:24",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin\\contracts-upgradeable\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0xEE158E19450d4De36222E8C0F894a1193408885A"
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@
 |-------------------------------|-----------------------|-------------|---------------------------------|
 | **lift**                      | Yes                   | Lifter      | `bytes`                         |
 | **permitLift**                | No                    | Lifter      | `bytes32`                       |
-| **proxyLift**                 | No                    | Anyone      | `bytes32`                       |
 | **predictionMarketLift**      | Yes                   | Lifter      | Derived from lifter ETH address |
 | **predictionMarketPermitLift**| No                    | Lifter      | Derived from lifter ETH address |
 | **predictionMarketProxyLift** | No                    | Anyone      | Derived from lifter ETH address |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ Note: when deploying on mainnet the contract `--owner` address must be specified
 #### Deploy Truth Token Implementation
 `npx hardhat implementation token --network <network>`
 
+#### Update Truth Token Manifest
+`npx hardhat manifest token <token_address> --network <network>`
+
 #### Deploy Truth Bridge
 `npx hardhat deploy bridge --token <token_address> [--owner owner_address] --network <network> --env <environment name>`
 
@@ -93,3 +96,6 @@ Note: when deploying on mainnet the contract `--owner` address must be specified
 
 #### Deploy Truth Bridge Implementation
 `npx hardhat implementation bridge --network <network>`
+
+#### Update Truth Bridge Manifest
+`npx hardhat manifest bridge <bridge_address> --network <network>`

--- a/contracts/TruthBridge.sol
+++ b/contracts/TruthBridge.sol
@@ -217,24 +217,6 @@ contract TruthBridge is ITruthBridge, Initializable, Ownable2StepUpgradeable, Pa
   }
 
   /**
-   * @dev lift variant accepting an ERC-2612 permit and lifter address to enable proxyied lifting.
-   */
-  function proxyLift(
-    address token,
-    address lifter,
-    bytes32 t2PubKey,
-    uint256 amount,
-    uint256 deadline,
-    uint8 v,
-    bytes32 r,
-    bytes32 s
-  ) external whenNotPaused nonReentrant {
-    if (t2PubKey == bytes32(0)) revert InvalidT2Key();
-    IERC20Permit(token).permit(lifter, address(this), amount, deadline, v, r, s);
-    emit LogLifted(token, t2PubKey, _lift(lifter, token, amount));
-  }
-
-  /**
    * @dev Lifts tokens to the derived T2 account of the caller on the prediction market, provided they have first been approved.
    */
   function predictionMarketLift(address token, uint256 amount) external whenNotPaused nonReentrant {

--- a/contracts/TruthToken.sol
+++ b/contracts/TruthToken.sol
@@ -8,6 +8,12 @@ import '@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 
 contract TruthToken is Initializable, ERC20Upgradeable, ERC20PermitUpgradeable, Ownable2StepUpgradeable, UUPSUpgradeable {
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+  
   function initialize(string calldata name, string calldata symbol_, uint256 supply, address owner_) public initializer {
     __Ownable_init(owner_);
     __Ownable2Step_init();

--- a/contracts/interfaces/ITruthBridge.sol
+++ b/contracts/interfaces/ITruthBridge.sol
@@ -16,7 +16,6 @@ interface ITruthBridge {
   function publishRoot(bytes32 rootHash, uint256 expiry, uint32 t2TxId, bytes calldata confirmations) external;
   function lift(address token, bytes calldata t2PubKey, uint256 amount) external;
   function permitLift(address token, bytes32 t2PubKey, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
-  function proxyLift(address token, address lifter, bytes32 t2PubKey, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
   function predictionMarketLift(address token, uint256 amount) external;
   function predictionMarketPermitLift(address token, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
   function predictionMarketProxyLift(address token, address lifter, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;

--- a/contracts/test/ReentrantToken.sol
+++ b/contracts/test/ReentrantToken.sol
@@ -10,7 +10,6 @@ contract ReentrantToken is ERC20 {
     ClaimLower,
     Lift,
     PermitLift,
-    ProxyLift,
     PredicitonMarketLift,
     PredicitonMarketPermitLift,
     PredicitonMarketProxyLift
@@ -49,7 +48,6 @@ contract ReentrantToken is ERC20 {
     if (_reentryPoint == ReentryPoint.ClaimLower) _bridge.claimLower(_proof);
     else if (_reentryPoint == ReentryPoint.Lift) _bridge.lift(_token, _t2PubKeyBytes, _amount);
     else if (_reentryPoint == ReentryPoint.PermitLift) _bridge.permitLift(_token, _t2PubKey, _amount, _deadline, _v, _r, _s);
-    else if (_reentryPoint == ReentryPoint.ProxyLift) _bridge.proxyLift(_token, msg.sender, _t2PubKey, _amount, _deadline, _v, _r, _s);
     else if (_reentryPoint == ReentryPoint.PredicitonMarketLift) _bridge.predictionMarketLift(_token, _amount);
     else if (_reentryPoint == ReentryPoint.PredicitonMarketPermitLift) _bridge.predictionMarketPermitLift(_token, _amount, _deadline, _v, _r, _s);
     else if (_reentryPoint == ReentryPoint.PredicitonMarketProxyLift) _bridge.predictionMarketProxyLift(_token, msg.sender, _amount, _deadline, _v, _r, _s);


### PR DESCRIPTION
- removes `proxyLift` functionality from the bridge
- adds `disableInitializers` to the token constructor
- adds a new task to manually update the OZ manifest