### PR TITLE
Clarify relayer naming

### DIFF
--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -471,7 +471,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(PausableStorage)274_storage": {
+          "t_struct(PausableStorage)597_storage": {
             "label": "struct PausableUpgradeable.PausableStorage",
             "members": [
               {
@@ -483,7 +483,7 @@
             ],
             "numberOfBytes": "32"
           },
-          "t_struct(ReentrancyGuardStorage)338_storage": {
+          "t_struct(ReentrancyGuardStorage)661_storage": {
             "label": "struct ReentrancyGuardUpgradeable.ReentrancyGuardStorage",
             "members": [
               {

--- a/.openzeppelin/sepolia.json
+++ b/.openzeppelin/sepolia.json
@@ -54,7 +54,7 @@
             "label": "string",
             "numberOfBytes": "32"
           },
-          "t_struct(EIP712Storage)610_storage": {
+          "t_struct(EIP712Storage)724_storage": {
             "label": "struct EIP712Upgradeable.EIP712Storage",
             "members": [
               {

--- a/contracts/TruthToken.sol
+++ b/contracts/TruthToken.sol
@@ -8,12 +8,11 @@ import '@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol';
 
 contract TruthToken is Initializable, ERC20Upgradeable, ERC20PermitUpgradeable, Ownable2StepUpgradeable, UUPSUpgradeable {
-
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {
     _disableInitializers();
   }
-  
+
   function initialize(string calldata name, string calldata symbol_, uint256 supply, address owner_) public initializer {
     __Ownable_init(owner_);
     __Ownable2Step_init();

--- a/contracts/interfaces/ITruthBridge.sol
+++ b/contracts/interfaces/ITruthBridge.sol
@@ -21,9 +21,9 @@ interface ITruthBridge {
   function predictionMarketProxyLift(address token, address lifter, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
   function registerRelayer(address relayer) external;
   function deregisterRelayer(address relayer) external;
-  function setOnRampGas(uint256 onRampGas) external;
-  function completeOnRamp(uint256 amount, address user, uint8 v, bytes32 r, bytes32 s) external;
-  function recoverCosts() external;
+  function setRelayerGas(uint256 liftGas) external;
+  function relayerLift(uint256 amount, address user, uint8 v, bytes32 r, bytes32 s) external;
+  function relayerRefund() external;
   function usdcEth() external view returns (uint256 price);
   function claimLower(bytes calldata proof) external;
   function checkLower(

--- a/contracts/test/RejectingRelayer.sol
+++ b/contracts/test/RejectingRelayer.sol
@@ -15,11 +15,11 @@ contract RejectingRelayer {
     revert();
   }
 
-  function completeOnRamp(uint256 amount, address user, uint8 v, bytes32 r, bytes32 s) external {
-    _bridge.completeOnRamp(amount, user, v, r, s);
+  function relayerLift(uint256 amount, address user, uint8 v, bytes32 r, bytes32 s) external {
+    _bridge.relayerLift(amount, user, v, r, s);
   }
 
-  function recoverCosts() external {
-    _bridge.recoverCosts();
+  function relayerRefund() external {
+    _bridge.relayerRefund();
   }
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -227,7 +227,7 @@ function printErrorCodes() {
     'MissingTruth()',
     'NotAnAuthor()',
     'NotEnoughAuthors()',
-    'NothingToRecover()',
+    'NoRefundDue()',
     'RelayerOnly()',
     'RootHashIsUsed()',
     'T1AddressInUse(address)',

--- a/test/helper.js
+++ b/test/helper.js
@@ -215,7 +215,6 @@ function printErrorCodes() {
     'BadConfirmations()',
     'CannotChangeT2Key(bytes32)',
     'ExcessSlippage()',
-    'FeedFailure()',
     'InvalidCallback()',
     'InvalidProof()',
     'InvalidT1Key()',


### PR DESCRIPTION
- Rename relayer-related functions for clarity and in preparation for adding relayer lowering
- Remove superfluous "FeedFailure" zero check error on Chainlink result since dividing by zero automatically reverts cleanly in Solidity 0.8.x anyway, even in unchecked blocks
- Remove initialising the gas cost for now as it differs by environment