### PR TITLE
Prep for upgrade part 4

### DIFF
--- a/contracts/interfaces/ITruthBridge.sol
+++ b/contracts/interfaces/ITruthBridge.sol
@@ -7,9 +7,11 @@ interface ITruthBridge {
   event LogLifted(address indexed token, bytes32 indexed t2PubKey, uint256 amount);
   event LogLiftedToPredictionMarket(address indexed token, bytes32 indexed t2PubKey, uint256 amount);
   event LogLowerClaimed(uint32 indexed lowerId);
+  event LogRelayerLowered(uint32 indexed lowerId, uint256 amount);
   event LogRootPublished(bytes32 indexed rootHash, uint32 indexed t2TxId);
   event LogRelayerRegistered(address indexed relayer);
   event LogRelayerDeregistered(address indexed relayer);
+  event LogRefundFailed(address indexed relayer, int256 balance);
 
   function addAuthor(bytes calldata t1PubKey, bytes32 t2PubKey, uint256 expiry, uint32 t2TxId, bytes calldata confirmations) external;
   function removeAuthor(bytes32 t2PubKey, bytes calldata t1PubKey, uint256 expiry, uint32 t2TxId, bytes calldata confirmations) external;
@@ -21,9 +23,8 @@ interface ITruthBridge {
   function predictionMarketRecipientLift(address token, bytes32 t2PubKey, uint256 amount) external;
   function registerRelayer(address relayer) external;
   function deregisterRelayer(address relayer) external;
-  function setRelayerGas(uint256 liftGas) external;
-  function relayerLift(uint256 amount, address user, uint8 v, bytes32 r, bytes32 s) external;
-  function relayerRefund() external;
+  function relayerLift(uint256 gasCost, uint256 amount, address user, uint8 v, bytes32 r, bytes32 s, bool triggerRefund) external;
+  function relayerLower(uint256 gasCost, bytes calldata proof, bool triggerRefund) external;
   function usdcEth() external view returns (uint256 price);
   function claimLower(bytes calldata proof) external;
   function checkLower(

--- a/contracts/test/ReentrantToken.sol
+++ b/contracts/test/ReentrantToken.sol
@@ -10,8 +10,8 @@ contract ReentrantToken is ERC20 {
     ClaimLower,
     Lift,
     PermitLift,
-    PredicitonMarketLift,
-    PredicitonMarketPermitLift,
+    PredictionMarketLift,
+    PredictionMarketPermitLift,
     PredictionMarketRecipientLift
   }
 
@@ -48,8 +48,8 @@ contract ReentrantToken is ERC20 {
     if (_reentryPoint == ReentryPoint.ClaimLower) _bridge.claimLower(_proof);
     else if (_reentryPoint == ReentryPoint.Lift) _bridge.lift(_token, _t2PubKeyBytes, _amount);
     else if (_reentryPoint == ReentryPoint.PermitLift) _bridge.permitLift(_token, _t2PubKey, _amount, _deadline, _v, _r, _s);
-    else if (_reentryPoint == ReentryPoint.PredicitonMarketLift) _bridge.predictionMarketLift(_token, _amount);
-    else if (_reentryPoint == ReentryPoint.PredicitonMarketPermitLift) _bridge.predictionMarketPermitLift(_token, _amount, _deadline, _v, _r, _s);
+    else if (_reentryPoint == ReentryPoint.PredictionMarketLift) _bridge.predictionMarketLift(_token, _amount);
+    else if (_reentryPoint == ReentryPoint.PredictionMarketPermitLift) _bridge.predictionMarketPermitLift(_token, _amount, _deadline, _v, _r, _s);
     else if (_reentryPoint == ReentryPoint.PredictionMarketRecipientLift) _bridge.predictionMarketRecipientLift(_token, _t2PubKey, _amount);
   }
 }

--- a/test/user.js
+++ b/test/user.js
@@ -72,6 +72,14 @@ describe('User Functions', async () => {
           .withArgs(truth.address, t2PubKey, amount);
       });
 
+      it('in lifting tokens to the prediction market and the t2 public key specifed', async () => {
+        const recipientT2PubKey = randomBytes32();
+        await truth.approve(bridge.address, amount);
+        await expect(bridge.predictionMarketRecipientLift(truth.address, recipientT2PubKey, amount))
+          .to.emit(bridge, 'LogLiftedToPredictionMarket')
+          .withArgs(truth.address, recipientT2PubKey, amount);
+      });
+
       it('in lifting tokens to the prediction market with a valid permit', async () => {
         const permit = await getPermit(truth, owner, bridge, amount);
         await expect(bridge.predictionMarketPermitLift(truth.address, amount, permit.deadline, permit.v, permit.r, permit.s))
@@ -129,9 +137,11 @@ describe('User Functions', async () => {
       });
 
       it('attempting to lift to the prediction market when the contract is paused', async () => {
+        const recipientT2PubKey = randomBytes32();
         await bridge.pause();
         await truth.approve(bridge.address, amount);
         await expect(bridge.predictionMarketLift(truth.address, amount)).to.be.revertedWithCustomError(bridge, 'EnforcedPause');
+        await expect(bridge.predictionMarketRecipientLift(truth.address, recipientT2PubKey, amount)).to.be.revertedWithCustomError(bridge, 'EnforcedPause');
         const permit = await getPermit(truth, owner, bridge, amount);
         await expect(bridge.predictionMarketPermitLift(truth.address, amount, permit.deadline, permit.v, permit.r, permit.s)).to.be.revertedWithCustomError(
           bridge,

--- a/utils/costCalculator.js
+++ b/utils/costCalculator.js
@@ -1,0 +1,40 @@
+const addresses = require('./addresses.js');
+const network = hre.network.config.forking.url.includes('mainnet') ? 'mainnet' : 'sepolia';
+const REFUND_GAS_COST = addresses[network].usdc.toLowerCase() === '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' ? 79770 : 31340;
+const TX_PER_REFUND = 20;
+const REFUND_CONTRIBUTION = parseInt(REFUND_GAS_COST / TX_PER_REFUND);
+const DUMMY_GAS_COST = 1n;
+
+async function costLift(bridge, relayer, amount, permit, user) {
+  const args = [DUMMY_GAS_COST, amount, user.address, permit.v, permit.r, permit.s, false];
+  return calculateCosts(bridge, relayer, 'relayerLift', args, 120000);
+}
+
+async function costLower(bridge, relayer, lowerProof) {
+  const args = [DUMMY_GAS_COST, lowerProof, false];
+  return calculateCosts(bridge, relayer, 'relayerLower', args, 150000);
+}
+
+async function calculateCosts(bridge, relayer, method, args, maxGas) {
+  const triggerRefund = Math.random() < 1 / TX_PER_REFUND;
+  const data = bridge.interface.encodeFunctionData(method, args);
+  const feeData = await ethers.provider.getFeeData();
+  const maxFeePerGas = parseInt(feeData.maxFeePerGas);
+  const maxPriorityFeePerGas = parseInt(feeData.maxPriorityFeePerGas);
+  maxGas += triggerRefund ? REFUND_GAS_COST : 0;
+  const gasLimit = parseInt(maxGas * 1.3);
+  const { gas } = await ethers.provider.send('debug_traceCall', [
+    { to: bridge.address, data, from: relayer.address, maxFeePerGas, maxPriorityFeePerGas, gasLimit },
+    'latest'
+  ]);
+  const gasCost = parseInt((gas + REFUND_CONTRIBUTION) * 1.005); // 0.5% buffer
+  const { baseFeePerGas } = await ethers.provider.getBlock('latest');
+  const baseFee = parseInt(baseFeePerGas);
+  const effectiveGasPrice = baseFee + maxPriorityFeePerGas > maxFeePerGas ? maxFeePerGas : baseFee + maxPriorityFeePerGas;
+  const usdcEth = parseInt(await bridge.usdcEth());
+  const estimatedCost = parseInt((gasCost * effectiveGasPrice) / usdcEth);
+
+  return { gasEstimate: gas, gasCost, gasLimit, refundGas: REFUND_CONTRIBUTION, triggerRefund, txCostEstimate: estimatedCost };
+}
+
+module.exports = { costLift, costLower };


### PR DESCRIPTION
- Add `relayerLower`
- Remove `relayerLiftGas` setter
- Remove `relayerRefund`. To save gas refunds are now triggered within relayer calls (a try-catch prevents any failed refunds reverting the main call)
- Add costCalculator utility (contains the same functions used by the relayer service)
- Add remaining coverage tests

![image](https://github.com/user-attachments/assets/ebf39731-4668-44fc-9553-d6b5f0cc5370)
