### PR TITLE
Seal the token

### DIFF
--- a/contracts/TruthToken.sol
+++ b/contracts/TruthToken.sol
@@ -26,10 +26,6 @@ contract TruthToken is Initializable, ERC20Upgradeable, ERC20PermitUpgradeable, 
     return 10;
   }
 
-  function renounceOwnership() public view override onlyOwner {
-    revert('Disabled');
-  }
-
   function symbol() public pure override returns (string memory) {
     return 'TRUU';
   }

--- a/test/owner.js
+++ b/test/owner.js
@@ -57,32 +57,6 @@ describe('Owner Functions', async () => {
     });
   });
 
-  context('Renouncing ownership', async () => {
-    context('is disabled', async () => {
-      it('on the bridge', async () => {
-        expect(owner).to.equal(await bridge.owner());
-        await expect(bridge.renounceOwnership()).to.be.revertedWith('Disabled');
-        expect(owner).to.equal(await bridge.owner());
-      });
-
-      it('on the truth token', async () => {
-        expect(owner).to.equal(await truth.owner());
-        await expect(truth.renounceOwnership()).to.be.revertedWith('Disabled');
-        expect(owner).to.equal(await truth.owner());
-      });
-    });
-
-    context('fails', async () => {
-      it('on the bridge when the caller is not the owner', async () => {
-        await expect(bridge.connect(otherAccount).renounceOwnership()).to.be.revertedWithCustomError(bridge, 'OwnableUnauthorizedAccount');
-      });
-
-      it('on the truth token when the caller is not the owner', async () => {
-        await expect(truth.connect(otherAccount).renounceOwnership()).to.be.revertedWithCustomError(truth, 'OwnableUnauthorizedAccount');
-      });
-    });
-  });
-
   context('Pausing bridge functionality', async () => {
     context('succeeds', async () => {
       it('when the caller is the owner', async () => {
@@ -266,6 +240,28 @@ describe('Owner Functions', async () => {
           'OwnableUnauthorizedAccount'
         );
       });
+    });
+  });
+
+  context('Renouncing ownership', async () => {
+    it('fails on the bridge when the caller is not the owner', async () => {
+      await expect(bridge.connect(otherAccount).renounceOwnership()).to.be.revertedWithCustomError(bridge, 'OwnableUnauthorizedAccount');
+    });
+
+    it('fails on the token when the caller is not the owner', async () => {
+      await expect(truth.connect(otherAccount).renounceOwnership()).to.be.revertedWithCustomError(truth, 'OwnableUnauthorizedAccount');
+    });
+
+    it('is disabled on the bridge', async () => {
+      expect(owner).to.equal(await bridge.owner());
+      await expect(bridge.renounceOwnership()).to.be.revertedWith('Disabled');
+      expect(owner).to.equal(await bridge.owner());
+    });
+
+    it('succeeds on the token', async () => {
+      expect(owner).to.equal(await truth.owner());
+      await truth.renounceOwnership();
+      expect(ZERO_ADDRESS).to.equal(await truth.owner());
     });
   });
 });


### PR DESCRIPTION
- Re-enables `renounceOwnership` in Truth Token by removing its current override.

- Once upgraded, the token owner can relinquish their ownership (sets the owner to the zero address), permanently locking the contract and making it un-upgradeable.