### PR TITLE
Add cancelLower function to Truth Bridge

### DIFF
--- a/contracts/interfaces/ITruthBridge.sol
+++ b/contracts/interfaces/ITruthBridge.sol
@@ -26,6 +26,7 @@ interface ITruthBridge {
   function relayerLift(uint256 gasCost, uint256 amount, address user, uint8 v, bytes32 r, bytes32 s, bool triggerRefund) external;
   function relayerLower(uint256 gasCost, bytes calldata proof, bool triggerRefund) external;
   function usdcEth() external view returns (uint256 price);
+  function cancelLower(bytes32 t2PubKey, uint8 wallletType, bytes calldata proof) external;
   function claimLower(bytes calldata proof) external;
   function checkLower(
     bytes calldata proof

--- a/contracts/test/ReentrantToken.sol
+++ b/contracts/test/ReentrantToken.sol
@@ -7,6 +7,7 @@ import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 
 contract ReentrantToken is ERC20 {
   enum ReentryPoint {
+    CancelLower,
     ClaimLower,
     Lift,
     PermitLift,
@@ -27,6 +28,7 @@ contract ReentrantToken is ERC20 {
   uint8 private _v;
   bytes32 private _r;
   bytes32 private _s;
+  uint8 private _walletType;
 
   constructor(ITruthBridge bridge) ERC20('R20', 'R20') {
     _mint(msg.sender, 100000000000000000);
@@ -45,7 +47,8 @@ contract ReentrantToken is ERC20 {
   }
 
   function _attemptReentry() private {
-    if (_reentryPoint == ReentryPoint.ClaimLower) _bridge.claimLower(_proof);
+    if (_reentryPoint == ReentryPoint.CancelLower) _bridge.cancelLower(_t2PubKey, _walletType, _proof);
+    else if (_reentryPoint == ReentryPoint.ClaimLower) _bridge.claimLower(_proof);
     else if (_reentryPoint == ReentryPoint.Lift) _bridge.lift(_token, _t2PubKeyBytes, _amount);
     else if (_reentryPoint == ReentryPoint.PermitLift) _bridge.permitLift(_token, _t2PubKey, _amount, _deadline, _v, _r, _s);
     else if (_reentryPoint == ReentryPoint.PredictionMarketLift) _bridge.predictionMarketLift(_token, _amount);

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -242,6 +242,7 @@ function printErrorCodes() {
     'AlreadyAdded()',
     'AmountTooLow()',
     'BadConfirmations()',
+    'BadWalletType()',
     'CannotChangeT2Key(bytes32)',
     'InvalidCaller()',
     'InvalidProof()',


### PR DESCRIPTION
- Presently there is no way to back out of a lower once the claim data has been generated.
- This change provides a means for the intended T1 recipient (or the owner, in the case of the recipient being unavailable) to revert the lower by: 
  - marking it as claimed and emitting a lower event
  - immediately emitting a lift event for the total "lowered" amount
  
- When a lower is cancelled in this way no funds are transferred on T1, they remain locked in the bridge and thus owned by T2 throughout.
- Implementing the function using the existing events mechanism keeps the changes isolated to the contract, no changes to T2 or the dapps are required.
- Because the originating T2 account and wallet type are not available in the lower proof, these must be passed as additional arguments. A future improvement will be to replace this implementation with one that returns the funds to the correct sender wallet automatically, but this requires changes to T2 first.

- Coverage:
![image](https://github.com/user-attachments/assets/04ee2e49-a566-44c9-8df7-d700e17e1f10)
